### PR TITLE
Update 03.methods.md

### DIFF
--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -44,7 +44,7 @@ We used Control-FREEC [@doi:10/ckt4vz; @doi:10/c6bcps] v8.7 for copy number vari
 ### Somatic Structural Variant Calling
 
 We used Manta SV [@doi:10/gf3ggb] v1.4.0 for structural variant (SV) calls.
-Manta SV calling was also limited to regions using in Strelka2.
+Manta SV calling was also limited to regions used in Strelka2.
 We also ran LUMPY SV [@doi:10/gf3ggc] v0.2.13 in express mode using default parameters. 
 The hg38 reference used was also limited to canonical chromosome regions.
 

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -45,8 +45,8 @@ We used Control-FREEC [@doi:10/ckt4vz; @doi:10/c6bcps] v8.7 for copy number vari
 
 We used Manta SV [@doi:10/gf3ggb] v1.4.0 for structural variant (SV) calls.
 Manta SV calling was also limited to regions using in Strelka2.
-LUMPY SV [@doi:10/gf3ggc] v0.2.13 was also used for SV calls.
-LUMPY SV express was run using default parameters on hg38 human genome reference.
+We also ran LUMPY SV [@doi:10/gf3ggc] v0.2.13 in express mode using default parameters. 
+The hg38 reference used was also limited to canonical chromosome regions.
 
 ### Gene Expression Abundance Estimation
 We used STAR [@doi:10/f4h523] v2.6.1d to align paired-end RNA-seq reads.

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -44,7 +44,9 @@ We used Control-FREEC [@doi:10/ckt4vz; @doi:10/c6bcps] v8.7 for copy number vari
 ### Somatic Structural Variant Calling
 
 We used Manta SV [@doi:10/gf3ggb] v1.4.0 for structural variant (SV) calls.
-SV calling was also limited to regions using in Strelka2.
+Manta SV calling was also limited to regions using in Strelka2.
+LUMPY SV [@doi:10/gf3ggc] v0.2.13 was also used for SV calls.
+LUMPY SV express was run using default parameters on hg38 human genome reference.
 
 ### Gene Expression Abundance Estimation
 We used STAR [@doi:10/f4h523] v2.6.1d to align paired-end RNA-seq reads.


### PR DESCRIPTION
Add information for LUMPY SV to somatic structural variant calling section of methods. Include the citation and version of LUMPY used in analysis, as well as the default parameters, express command, and hg38 reference.