### PR TITLE
add pnoc details from TGEN

### DIFF
--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -14,6 +14,7 @@ All RNA used for library prep had a minimum RIN of 7 but no QC thresholds were i
 For library preparation, 500ng of nucleic acids were used as input for RNA-Seq and WXS.
 The RNA prep was performed using the TruSeq RNA Sample Prep Kit (Illumina, #FC-122-1001) and the exome prep was performed using KAPA Library Preparation Kit (Kapa Biosystems, #KK8201) using Agilent's SureSelect Human All Exon V5 backbone with custom probes. 
 These probes include CGH probes that target 44,000 evenly spaced genomic loci to assess copy number changes, as well as probes that tile across tumor suppressor genes and genes involved in common cancer translocations.
+All extractions and library preparations were performed according to manufacturer's instructions.
 
 ##### CBTTC samples
 


### PR DESCRIPTION
I confirmed that all kits were used according to manufacturer protocols, however @cgreene, you suggested linking to the actual instructions. Do you still want me to do this? I added cat#s in the previous PR.