### PR TITLE
CNV consensus calls methods add

### DIFF
--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -143,18 +143,15 @@ We used GISTIC [@doi:10.1186/gb-2011-12-4-r41] v.2.0.23 on the CNVkit and the co
 #### Consensus CNV Calling
 
 For each caller and sample, CNVs were called based on consensus amongst the calls made by ControlFreeC, CNVKit, and Manta.
-CNVs called significant by ControlFreec (pval = 0.01) were used.
+CNVs called significant by ControlFreec (pval = 0.01) were included in the consensus calling.
+The calls from a given sample were compared pair wise between the three callers.
+CNVs of the same sample and call method were merged if they overlapped 10,000 bp.
 
-For a given sample if a CNV from one caller overlapped 50% or more with at least one CNV from another caller, the common region of the overlapping CNV would be the new consensus CNV.
-Filter out any CNVs that overlap 50% or more with Immunoglobulin, telomeric, centromeric, seg_dup regions or were longer than 3000bp.
+Resolved overlapping segments where duplications are embedded within larger deletion segments, or deletions within duplications.
 
-We merged any CNVs of the same sample and call method if they overlapped or within 10,000 bp (We consider CNV calls within 10,000 bp the same CNV)
-Reformat the columns of the files (So the info are easier to read)
-Call consensus by comparing CNVs from 2 call methods at a time.
-
-Sample/caller combination files with more than 2500 CNVs called were removed from the set; We believe these to be noisy/poor quality samples (this came from what GISTIC uses as a cutoff for noisy samples).
-
-Resolve overlapping segments where duplications are embedded within larger deletion segments, or deletions within duplications.
+If a CNV from one caller overlapped 50% or more with at least one CNV from another caller, the common region of the overlapping CNV was considered the new consensus CNV.
+We filtered out any CNVs that overlapped 50% or more with Immunoglobulin, telomeric, centromeric, seg_dup regions or were longer than 3000bp.
+Sample/caller combination files with more than 2500 CNVs called were removed from the set; We believe these to be noisy/poor quality samples (this was based on cutoffs used in GISTIC methods [@doi:10.1186/gb-2011-12-4-r41]).
 
 ### Somatic Structural Variant Calling (WGS samples only)
 

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -108,7 +108,7 @@ The 0.05 VAF increased the true positive rate for INDELs and decreased the false
 The final VCF was filtered for PASS variants with TYPE=StronglySomatic.
 Lancet v1.0.7 was run using default parameters, except for those noted below.
 For input intervals to Lancet WGS, a reference BED was created by using only the UTR, exome, and start/stop codon features of the GENCODE 31 reference, augmented as recommended with PASS variant calls from Strelka2 and Mutect2 [@doi:10.1101/623702].
-These intervals were then padded by 300 bp on each side during Lancet variant calling. 
+These intervals were then padded by 300 bp on each side during Lancet variant calling.
 Per recommendations by the New York Genome Center [@doi:10.1101/623702], for WGS samples, the Lancet input intervals described above were augmented with PASS variant calls from Strelka2 and Mutect2 as validation.
 
 #### VCF annotation and MAF creation
@@ -139,6 +139,22 @@ Theta2 [@doi:10.1093/bioinformatics/btu651] used VarDict germline and somatic ca
 Theta2 purity was added as an optional parameter to CNVkit to adjust copy number calls.
 CNVkit was run on human genome reference hg38 using the optional parameters of Theta2 purity and BAF adjustment for tumor-normal pairs.
 We used GISTIC [@doi:10.1186/gb-2011-12-4-r41] v.2.0.23 on the CNVkit and the consensus CNV segmentation files to generate gene-level copy number abundance (Log R Ratio) as well as chromosomal arm copy number alterations using the parameters specified in the [OpenPBTA Analysis repository](https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/analyses/run-gistic/scripts/run-gistic-openpbta.sh).
+
+#### Consensus CNV Calling
+
+For each caller and sample, CNVs were called based on consensus amongst the calls made by ControlFreeC, CNVKit, and Manta.
+CNVs called significant by ControlFreec (pval = 0.01) were used.
+
+For a given sample if a CNV from one caller overlapped 50% or more with at least one CNV from another caller, the common region of the overlapping CNV would be the new consensus CNV.
+Filter out any CNVs that overlap 50% or more with Immunoglobulin, telomeric, centromeric, seg_dup regions or were longer than 3000bp.
+
+We merged any CNVs of the same sample and call method if they overlapped or within 10,000 bp (We consider CNV calls within 10,000 bp the same CNV)
+Reformat the columns of the files (So the info are easier to read)
+Call consensus by comparing CNVs from 2 call methods at a time.
+
+Sample/caller combination files with more than 2500 CNVs called were removed from the set; We believe these to be noisy/poor quality samples (this came from what GISTIC uses as a cutoff for noisy samples).
+
+Resolve overlapping segments where duplications are embedded within larger deletion segments, or deletions within duplications.
 
 ### Somatic Structural Variant Calling (WGS samples only)
 
@@ -310,7 +326,7 @@ High-grade glioma (HGG) subtypes were derived using the criteria below (addition
 5. If a sample was initially classified as HGAT, had no defining histone mutations, and a BRAF V600E mutation, it was subtyped as `BRAF V600E`.
 6. All other high-grade glioma samples that did not meet any of these criteria were subtyped as `HGG, H3 wildtype`.
 
-Non-MB and non-ATRT embryonal (`Embryonal tumor` in the `broad_histology` column of the metadata pbta-histologies.tsv) subtypes were derived using the criteria below [@pmid:30249036; @doi:10.1007/s00381-017-3551-6; @url:https://www.cancer.gov/types/brain/hp/child-cns-embryonal-treatment-pdq; @doi:10.3390/ijms21051818]. 
+Non-MB and non-ATRT embryonal (`Embryonal tumor` in the `broad_histology` column of the metadata pbta-histologies.tsv) subtypes were derived using the criteria below [@pmid:30249036; @doi:10.1007/s00381-017-3551-6; @url:https://www.cancer.gov/types/brain/hp/child-cns-embryonal-treatment-pdq; @doi:10.3390/ijms21051818].
 Additional details can be found in the analysis [notebook](https://alexslemonade.github.io/OpenPBTA-analysis/analyses/molecular-subtyping-embryonal/04-table-prep.nb.html).
 
 1. Any RNA-seq biospecimen with <i>LIN28A</i>a overexpression, plus a <i>TTYH1</i> fusion (5' partner) with a gene adjacent or within the C19MC miRNA cluster and/or copy number amplification of the C19MC region was subtyped as `ETMR, C19MC-altered` (Embryonal tumor with multilayer rosettes, chromosome 19 miRNA cluster altered).
@@ -320,7 +336,7 @@ Additional details can be found in the analysis [notebook](https://alexslemonade
 5. Non-MB and non-ATRT embryonal tumors with over-expression and/or gene fusions in <i>FOXR2</i> were subtyped as `CNS NB-FOXR2` (CNS neuroblastoma with <i>FOXR2</i> activation).
 6. Non-MB and non-ATRT embryonal tumors with <i>CIC-NUTM1</i> or other <i>CIC</i> fusions, were subtyped as `CNS EFT-CIC` (CNS Ewing sarcoma family tumor with <i>CIC</i> alteration).
 7. Non-MB and non-ATRT embryonal tumors that did not fit any of the above categories were subtyped as CNS Embryonal, NOS (CNS Embryonal tumor, not otherwise specified).
- 
+
 
 #### Survival
 

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -143,9 +143,9 @@ We used GISTIC [@doi:10.1186/gb-2011-12-4-r41] v.2.0.23 on the CNVkit and the co
 #### Consensus CNV Calling
 
 For each caller and sample, CNVs were called based on consensus amongst ControlFreeC [@doi:10/ckt4vz; @doi:10/c6bcps], CNVKit [@doi:10.1371/journal.pcbi.1004873], and Manta [@doi:10/gf3ggb].
-CNVs called significant by ControlFreeC (pval = 0.01) were included in the consensus calling.
+CNVs called significant by ControlFreeC (pval < 0.01) were included in the consensus calling.
 
-Sample and caller combination files with more than 2500 CNVs called were removed from the set; we believe these to be noisy and poor quality samples (this is based on cutoffs used in GISTIC methods [@doi:10.1186/gb-2011-12-4-r41]).
+Sample and caller combination files with more than 2500 CNVs called were removed from the set; we expect these to be noisy and poor quality samples based on cutoffs used in GISTIC [@doi:10.1186/gb-2011-12-4-r41].
 For each sample, regions with reciprocal overlap of at least 50% between two of the three callers were included in the final consensus set.
 CNV regions within 10,000 bp of each other with the same direction of gain or loss were merged into single region.
 We filtered out any CNVs that overlapped 50% or more with immunoglobulin, telomeric, centromeric, segment duplicated regions or were shorter than 3000 bp.

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -142,16 +142,15 @@ We used GISTIC [@doi:10.1186/gb-2011-12-4-r41] v.2.0.23 on the CNVkit and the co
 
 #### Consensus CNV Calling
 
-For each caller and sample, CNVs were called based on consensus amongst the calls made by ControlFreeC, CNVKit, and Manta.
-CNVs called significant by ControlFreec (pval = 0.01) were included in the consensus calling.
-The calls from a given sample were compared pair wise between the three callers.
+For each caller and sample, CNVs were called based on consensus amongst ControlFreeC [@doi:10/ckt4vz; @doi:10/c6bcps], CNVKit [@doi:10.1371/journal.pcbi.1004873], and Manta [@doi:10/gf3ggb].
+CNVs called significant by ControlFreeC (pval = 0.01) were included in the consensus calling.
+
+The calls from a given sample were compared pairwise between the three callers.
 CNVs of the same sample and call method were merged if they overlapped 10,000 bp.
-
-Resolved overlapping segments where duplications are embedded within larger deletion segments, or deletions within duplications.
-
 If a CNV from one caller overlapped 50% or more with at least one CNV from another caller, the common region of the overlapping CNV was considered the new consensus CNV.
-We filtered out any CNVs that overlapped 50% or more with Immunoglobulin, telomeric, centromeric, seg_dup regions or were longer than 3000bp.
-Sample/caller combination files with more than 2500 CNVs called were removed from the set; We believe these to be noisy/poor quality samples (this was based on cutoffs used in GISTIC methods [@doi:10.1186/gb-2011-12-4-r41]).
+
+We filtered out any CNVs that overlapped 50% or more with immunoglobulin, telomeric, centromeric, segment duplicated regions or were longer than 3000bp.
+Sample and caller combination files with more than 2500 CNVs called were removed from the set; we believe these to be noisy and poor quality samples (this is based on cutoffs used in GISTIC methods [@doi:10.1186/gb-2011-12-4-r41]).
 
 ### Somatic Structural Variant Calling (WGS samples only)
 

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -145,12 +145,10 @@ We used GISTIC [@doi:10.1186/gb-2011-12-4-r41] v.2.0.23 on the CNVkit and the co
 For each caller and sample, CNVs were called based on consensus amongst ControlFreeC [@doi:10/ckt4vz; @doi:10/c6bcps], CNVKit [@doi:10.1371/journal.pcbi.1004873], and Manta [@doi:10/gf3ggb].
 CNVs called significant by ControlFreeC (pval = 0.01) were included in the consensus calling.
 
-The calls from a given sample were compared pairwise between the three callers.
-CNVs of the same sample and call method were merged if they overlapped 10,000 bp.
-If a CNV from one caller overlapped 50% or more with at least one CNV from another caller, the common region of the overlapping CNV was considered the new consensus CNV.
-
-We filtered out any CNVs that overlapped 50% or more with immunoglobulin, telomeric, centromeric, segment duplicated regions or were longer than 3000bp.
 Sample and caller combination files with more than 2500 CNVs called were removed from the set; we believe these to be noisy and poor quality samples (this is based on cutoffs used in GISTIC methods [@doi:10.1186/gb-2011-12-4-r41]).
+For each sample, regions with reciprocal overlap of at least 50% between two of the three callers were included in the final consensus set.
+CNV regions within 10,000 bp of each other with the same direction of gain or loss were merged into single region.
+We filtered out any CNVs that overlapped 50% or more with immunoglobulin, telomeric, centromeric, segment duplicated regions or were shorter than 3000 bp.
 
 ### Somatic Structural Variant Calling (WGS samples only)
 


### PR DESCRIPTION
### Purpose

Added a section about how the CNV consensus calls. I based this off of what is in the [CNV consensus call README said](https://github.com/AlexsLemonade/OpenPBTA-analysis/tree/master/analyses/copy_number_consensus_call) 

### Issue
#92 

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?
I am unsure about how offbase my description of these methods are. So this should be reviewed by those who have a better idea of this analysis(@jashapiro and @fingerfen)
Hopefully what I've put down helps get you started. 

#### Is the pull request ready for review?
Yes?

### Pull review checklist

Unless otherwise noted above, this PR will be considered ready for review when all four items have been checked.

- [x] All changes to text follow "one sentence per line" [[Manubot instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#manubot-markdown)]
- [x] All citations follow the [Manubot citation instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#citations)

There are no figures or tables added.
- [x] All changes or additions to tables follow the [Manubot table instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#tables)
- [x] All figures follow the [Manubot figure instructions](https://github.com/jaclyn-taroni/OpenPBTA-manuscript/blob/master/USAGE.md#figures)
