### PR TITLE
Add telomerase activity prediction module authors

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -131,6 +131,16 @@ authors:
     affiliations:
       - Center for Data-Driven Discovery, Children's Hospital of Philadelphia
       - Department of Bioinformatics and Health Informatics, Children's Hospital of Philadelphia
+  - github: NNoureen
+    name: Nighat Noureen
+    initials: NN
+    orcid: 0000-0001-7495-8201
+    email: noureen@uthscsa.edu
+    contributions:
+      - Formal analysis
+      - Writing - Original draft
+    affiliations: 
+      - Greehey Children's Cancer Research Institute, UT Health San Antonio
   - github: zhangb1
     name: Bo Zhang
     initials: BZ
@@ -328,6 +338,18 @@ authors:
     affiliations:
       - Hackensack Meridian School of Medicine
       - Hackensack University Medical Center
+  - github: syzheng 
+    name: Siyuan Zheng
+    initials: SZ
+    email: zhengs3@uthscsa.edu
+    twitter: zhengsiyuan
+    orcid: 0000-0002-1031-9424
+    contributions:
+      - Formal analysis
+      - Writing - Original draft
+      - Supervision
+    affiliations:
+      - Greehey Children's Cancer Research Institute, UT Health San Antonio
   - github: jvlilly
     name: Jena V. Lilly
     initials: JVL


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose

Addresses #115 - adds authors of the telomerase activity prediction module to the author list in `content/metadata.yaml`.

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

@syzheng and @NNoureen can you double check the information I've added here and make sure you agree with this change? Thanks!