### PR TITLE
CRANIO subtype section added

### DIFF
--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -318,4 +318,3 @@ adamantinomatous
 CRANIO
 ACP
 craniopharyngiomas
-

--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -314,3 +314,8 @@ Fraumeni
 allelic
 IARC
 vcf
+adamantinomatous
+CRANIO
+ACP
+craniopharyngiomas
+

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -391,7 +391,7 @@ Additional details can be found in the analysis [notebook](https://alexslemonade
 Craniopharyngiomas (CRANIO) were subtyped into adamantinomatous (`CRANIO, ADAM`), papillary (`CRANIO, PAP`) or undetermined (`CRANIO, To be classified`) based on the following criteria:
 1. Craniopharyngiomas with BRAF p.V600E mutation in patients age over 40-years-old were subtyped as `CRANIO, PAP`.
 2. Craniopharyngiomas with mutations in exon 3 of _CTNNB1_ in patients age below 40-years-old were subtyped as `CRANIO, ADAM`.
-3. Craniopharyngiomas that does not fall into the above two categories were subtyped as `CRANIO, To be classified`. 
+3. Craniopharyngiomas that do not fall into the above two categories were subtyped as `CRANIO, To be classified`. 
 The age of the patients were added as criteria for subtyping since papillary craniopharyngiomas (PCP) occur almost exclusively in adults and adamantinomatous craniopharyngiomas (ACP) occur mostly in childhood or young adolescence [@doi:10.3171/jns.1995.83.2.0206; @doi:10.3171/jns.1998.89.4.0547]. 
 
 #### TP53 Alteration Annotation

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -388,6 +388,12 @@ Additional details can be found in the analysis [notebook](https://alexslemonade
 6. Non-MB and non-ATRT embryonal tumors with <i>CIC-NUTM1</i> or other <i>CIC</i> fusions, were subtyped as `CNS EFT-CIC` (CNS Ewing sarcoma family tumor with <i>CIC</i> alteration).
 7. Non-MB and non-ATRT embryonal tumors that did not fit any of the above categories were subtyped as CNS Embryonal, NOS (CNS Embryonal tumor, not otherwise specified).
 
+Craniopharyngiomas (CRANIO) were subtyped into adamantinomatous (`CRANIO, ADAM`), papillary (`CRANIO, PAP`) or undetermined (`CRANIO, To be classified`) based on the following criteria:
+1. Craniopharyngiomas with BRAF p.V600E mutation in patients age over 40-years-old were subtyped as `CRANIO, PAP`.
+2. Craniopharyngiomas with mutations in exon 3 of _CTNNB1_ in patients age below 40-years-old were subtyped as `CRANIO, ADAM`.
+3. Craniopharyngiomas that does not fall into the above two categories were subtyped as `CRANIO, To be classified`. 
+The age of the patients were added as criteria for subtyping since papillary craniopharyngiomas (PCP) occur almost exclusively in adults and adamantinomatous craniopharyngiomas (ACP) occur mostly in childhood or young adolescence [@doi:10.3171/jns.1995.83.2.0206; @doi:10.3171/jns.1998.89.4.0547]. 
+
 #### TP53 Alteration Annotation
 
 In addition to tumor types mentioned above, TP53 altered status is also annotated for all samples and if a sample is determined to be either `TP53 loss` or `TP53 activated`, this annotation will be included in the `molecular_subtype` column. 

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -388,11 +388,10 @@ Additional details can be found in the analysis [notebook](https://alexslemonade
 6. Non-MB and non-ATRT embryonal tumors with <i>CIC-NUTM1</i> or other <i>CIC</i> fusions, were subtyped as `CNS EFT-CIC` (CNS Ewing sarcoma family tumor with <i>CIC</i> alteration).
 7. Non-MB and non-ATRT embryonal tumors that did not fit any of the above categories were subtyped as CNS Embryonal, NOS (CNS Embryonal tumor, not otherwise specified).
 
-Craniopharyngiomas (CRANIO) were subtyped into adamantinomatous (`CRANIO, ADAM`), papillary (`CRANIO, PAP`) or undetermined (`CRANIO, To be classified`) based on the following criteria:
-1. Craniopharyngiomas with BRAF p.V600E mutation in patients age over 40-years-old were subtyped as `CRANIO, PAP`.
-2. Craniopharyngiomas with mutations in exon 3 of _CTNNB1_ in patients age below 40-years-old were subtyped as `CRANIO, ADAM`.
+Craniopharyngiomas (CRANIO) were subtyped into adamantinomatous (`CRANIO, ADAM`), papillary (`CRANIO, PAP`) or undetermined (`CRANIO, To be classified`) based on the following criteria [@doi:10.3171/jns.1995.83.2.0206; @doi:10.3171/jns.1998.89.4.0547]:
+1. Craniopharyngiomas from patients over 40 years old with a _BRAF_ p.V600E mutation were subtyped as `CRANIO, PAP`.
+2. Craniopharyngiomas from patients younger than 40 years old with mutations in exon 3 of _CTNNB1_ were subtyped as `CRANIO, ADAM`.
 3. Craniopharyngiomas that do not fall into the above two categories were subtyped as `CRANIO, To be classified`. 
-The age of the patients were added as criteria for subtyping since papillary craniopharyngiomas (PCP) occur almost exclusively in adults and adamantinomatous craniopharyngiomas (ACP) occur mostly in childhood or young adolescence [@doi:10.3171/jns.1995.83.2.0206; @doi:10.3171/jns.1998.89.4.0547]. 
 
 #### TP53 Alteration Annotation
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose

Added subtype criteria for craniopharyngioma.

### Issue
https://github.com/AlexsLemonade/OpenPBTA-manuscript/issues/136

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?
Please check to see the references about age distribution of craniopharyngioma subtypes are ok.

#### Is there anything that you want to discuss further?
No.

#### Is the pull request ready for review?
Yes.

### Pull review checklist

Unless otherwise noted above, this PR will be considered ready for review when all four items have been checked.

- [x] All changes to text follow "one sentence per line" [[Manubot instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#manubot-markdown)]
- [x] All citations follow the [Manubot citation instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#citations)
- [ ] All changes or additions to tables follow the [Manubot table instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#tables)
- [ ] All figures follow the [Manubot figure instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#figures)
- [ ] There are no new spelling errors identified by the [Manubot spellchecker](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#spellchecking)

### Spellcheck Step

The dictionary used for spellchecking can be updated.
Edit the file in `build/assets/custom-dictionary.txt` by adding new entries to the end.
You do not need to change anything else.
However, if you want to update the first line to have an accurate count of words and you want to remove non-unique ones, run the following command from within `build/assets` on your favorite OS X or Linux machine:
```
(( len = $(awk '!a[$0]++' < custom-dictionary.txt | wc -l ) - 1 )); tmpfile="$(mktemp)"; echo "personal_ws-1.1 en $len utf-8" > $tmpfile; tail -n +2 custom-dictionary.txt | awk '!a[$0]++' >> $tmpfile; mv $tmpfile custom-dictionary.txt
```
