### PR TITLE
Embryonal subtype update

### DIFF
--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -314,3 +314,11 @@ Fraumeni
 allelic
 IARC
 vcf
+HGNET
+PNET
+Supratentorial
+ependymoblastoma
+medulloepithelioma
+ros
+HGNET
+

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -377,15 +377,23 @@ High-grade glioma (HGG) subtypes were derived using the criteria below (addition
 5. If a sample was initially classified as HGAT, had no defining histone mutations, and a BRAF V600E mutation, it was subtyped as `BRAF V600E`.
 6. All other high-grade glioma samples that did not meet any of these criteria were subtyped as `HGG, H3 wildtype`.
 
-Non-MB and non-ATRT embryonal (`Embryonal tumor` in the `broad_histology` column of the metadata pbta-histologies.tsv) subtypes were derived using the criteria below [@pmid:30249036; @doi:10.1007/s00381-017-3551-6; @url:https://www.cancer.gov/types/brain/hp/child-cns-embryonal-treatment-pdq; @doi:10.3390/ijms21051818].
+Non-MB and non-ATRT embryonal tumors were subset from all embryonal tumor (`Embryonal tumor` in the `broad_histology` column of the metadata pbta-histologies.tsv) using the following criteria:
+1. An RNA-seq biospecimen sample includes a _TTYH1_ fusion (5' partner).
+2. An RNA-seq biospecimen sample includes a _MN1_ fusion (5' partner).
+Note that the `MN1--PATZ1` fusion is excluded as it is an entity separate of CNS HGNET-MN1 tumors [@doi:10.1111/nan.12626].
+3. Any sample with "Supratentorial or Spinal Cord PNET" or "Embryonal Tumor with Multilayered Rosettes" in the `pathology_diagnosis` column of the metadata `pbta-histologies.tsv`.
+4. Any sample with "Neuroblastoma" in the `pathology_diagnosis` column, where `primary_site` does not contain "Other locations NOS", `pathology_free_text_diagnosis` does not contain "peripheral" or "metastatic".
+5. Any sample with "Other" in the `pathology_diagnosis` column of the metadata, and with "embryonal tumor with multilayer rosettes, ros (who grade iv)", "embryonal tumor, nos, congenital type", "ependymoblastoma" or "medulloepithelioma" in the `pathology_free_text_diagnosis` column.
+
+Non-MB and non-ATRT embryonal tumors generated subtypes were derived using the criteria below [@pmid:30249036; @doi:10.1007/s00381-017-3551-6; @url:https://www.cancer.gov/types/brain/hp/child-cns-embryonal-treatment-pdq; @doi:10.3390/ijms21051818].
 Additional details can be found in the analysis [notebook](https://alexslemonade.github.io/OpenPBTA-analysis/analyses/molecular-subtyping-embryonal/04-table-prep.nb.html).
 
-1. Any RNA-seq biospecimen with <i>LIN28A</i> overexpression, plus a <i>TTYH1</i> fusion (5' partner) with a gene adjacent or within the C19MC miRNA cluster and/or copy number amplification of the C19MC region was subtyped as `ETMR, C19MC-altered` (Embryonal tumor with multilayer rosettes, chromosome 19 miRNA cluster altered).
-2. Any RNA-seq biospecimen with <i>LIN28A</i> overexpression, a <i>TTYH1</i> fusion (5' partner) with a gene adjacent or within the C19MC miRNA cluster but no evidence of copy number amplification of the C19MC region was subtyped as `ETMR, NOS` (Embryonal tumor with multilayer rosettes, not otherwise specified).
-3. Any RNA-seq biospecimen with a fusion having a 5' <i>MN1</i> and 3' <i>BEND2</i> or <i>CXXC5</i> partner were subtyped as `CNS HGNET-MN1` (Central nervous system (CNS) high-grade neuroepithelial tumor with _MN1_ alteration).
-4. Non-MB and non-ATRT embryonal tumors with internal tandem duplication of _BCOR_ were subtyped as `CNS HGNET-BCOR` (CNS high-grade neuroepithelial tumor with _BCOR_ alteration).
-5. Non-MB and non-ATRT embryonal tumors with over-expression and/or gene fusions in <i>FOXR2</i> were subtyped as `CNS NB-FOXR2` (CNS neuroblastoma with <i>FOXR2</i> activation).
-6. Non-MB and non-ATRT embryonal tumors with <i>CIC-NUTM1</i> or other <i>CIC</i> fusions, were subtyped as `CNS EFT-CIC` (CNS Ewing sarcoma family tumor with <i>CIC</i> alteration).
+1. Any RNA-seq biospecimen with _LIN28A_ overexpression, plus a _TYH1_ fusion (5' partner) with a gene adjacent or within the C19MC miRNA cluster and/or copy number amplification of the C19MC region was subtyped as `ETMR, C19MC-altered` (Embryonal tumor with multilayer rosettes, chromosome 19 miRNA cluster altered) [@doi:10.1007/s00401-012-1068-3; 10.1038/ng.2849].
+2. Any RNA-seq biospecimen with _LIN28A_ overexpression, a _TTYH1_ fusion (5' partner) with a gene adjacent or within the C19MC miRNA cluster but no evidence of copy number amplification of the C19MC region was subtyped as `ETMR, NOS` (Embryonal tumor with multilayer rosettes, not otherwise specified) [@doi:10.1007/s00401-012-1068-3; @doi:10.1038/ng.2849].
+3. Any RNA-seq biospecimen with a fusion having a 5' _MN1_ and 3' _BEND2_ or _CXXC5_ partner were subtyped as `CNS HGNET-MN1` (Central nervous system (CNS) high-grade neuroepithelial tumor with _MN1_ alteration).
+4. Non-MB and non-ATRT embryonal tumors with internal tandem duplication (as defined in this paper [@doi:10.1186/s12859-016-1031-8]) of _BCOR_ were subtyped as `CNS HGNET-BCOR` (CNS high-grade neuroepithelial tumor with _BCOR_ alteration).
+5. Non-MB and non-ATRT embryonal tumors with over-expression and/or gene fusions in _FOXR2_ were subtyped as `CNS NB-FOXR2` (CNS neuroblastoma with _FOXR2_ activation).
+6. Non-MB and non-ATRT embryonal tumors with _CIC-NUTM1_ or other _CIC_ fusions, were subtyped as `CNS EFT-CIC` (CNS Ewing sarcoma family tumor with _CIC_ alteration) [@doi:/j.cell.2016.01.015]
 7. Non-MB and non-ATRT embryonal tumors that did not fit any of the above categories were subtyped as `CNS Embryonal, NOS` (CNS Embryonal tumor, not otherwise specified).
 
 #### TP53 Alteration Annotation

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -386,7 +386,7 @@ Additional details can be found in the analysis [notebook](https://alexslemonade
 4. Non-MB and non-ATRT embryonal tumors with internal tandem duplication of _BCOR_ were subtyped as `CNS HGNET-BCOR` (CNS high-grade neuroepithelial tumor with _BCOR_ alteration).
 5. Non-MB and non-ATRT embryonal tumors with over-expression and/or gene fusions in <i>FOXR2</i> were subtyped as `CNS NB-FOXR2` (CNS neuroblastoma with <i>FOXR2</i> activation).
 6. Non-MB and non-ATRT embryonal tumors with <i>CIC-NUTM1</i> or other <i>CIC</i> fusions, were subtyped as `CNS EFT-CIC` (CNS Ewing sarcoma family tumor with <i>CIC</i> alteration).
-7. Non-MB and non-ATRT embryonal tumors that did not fit any of the above categories were subtyped as CNS Embryonal, NOS (CNS Embryonal tumor, not otherwise specified).
+7. Non-MB and non-ATRT embryonal tumors that did not fit any of the above categories were subtyped as `CNS Embryonal, NOS` (CNS Embryonal tumor, not otherwise specified).
 
 #### TP53 Alteration Annotation
 

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -377,13 +377,12 @@ High-grade glioma (HGG) subtypes were derived using the criteria below (addition
 5. If a sample was initially classified as HGAT, had no defining histone mutations, and a BRAF V600E mutation, it was subtyped as `BRAF V600E`.
 6. All other high-grade glioma samples that did not meet any of these criteria were subtyped as `HGG, H3 wildtype`.
 
-Non-MB and non-ATRT embryonal tumors were subset from all embryonal tumor (`Embryonal tumor` in the `broad_histology` column of the metadata pbta-histologies.tsv) using the following criteria:
-1. An RNA-seq biospecimen sample includes a _TTYH1_ fusion (5' partner).
-2. An RNA-seq biospecimen sample includes a _MN1_ fusion (5' partner).
-Note that the `MN1--PATZ1` fusion is excluded as it is an entity separate of CNS HGNET-MN1 tumors [@doi:10.1111/nan.12626].
-3. Any sample with "Supratentorial or Spinal Cord PNET" or "Embryonal Tumor with Multilayered Rosettes" in the `pathology_diagnosis` column of the metadata `pbta-histologies.tsv`.
-4. Any sample with "Neuroblastoma" in the `pathology_diagnosis` column, where `primary_site` does not contain "Other locations NOS", `pathology_free_text_diagnosis` does not contain "peripheral" or "metastatic".
-5. Any sample with "Other" in the `pathology_diagnosis` column of the metadata, and with "embryonal tumor with multilayer rosettes, ros (who grade iv)", "embryonal tumor, nos, congenital type", "ependymoblastoma" or "medulloepithelioma" in the `pathology_free_text_diagnosis` column.
+Embryonal tumors were included in non-MB and non-ATRT embryonal tumor subtyping if they met any of the following criteria:
+1. A _TTYH1_ (5' partner) fusion was detected.
+2. A _MN1_ (5' partner) fusion was detected, with the exception of `MN1--PATZ1` since it is an entity separate of CNS HGNET-MN1 tumors [@doi:10.1111/nan.12626].
+3. Pathology diagnoses included "Supratentorial or Spinal Cord PNET" or "Embryonal Tumor with Multilayered Rosettes".
+4. A pathology diagnosis of "Neuroblastoma", where the tumor was not indicated to be peripheral or metastatic and was located in the CNS.
+5. Any sample with "embryonal tumor with multilayer rosettes, ros (who grade iv)", "embryonal tumor, nos, congenital type", "ependymoblastoma" or "medulloepithelioma" in pathology free text.
 
 Non-MB and non-ATRT embryonal tumors identified with the above criteria were further subtyped using the criteria below [@pmid:30249036; @doi:10.1007/s00381-017-3551-6; @url:https://www.cancer.gov/types/brain/hp/child-cns-embryonal-treatment-pdq; @doi:10.3390/ijms21051818].
 Additional details can be found in the analysis [notebook](https://alexslemonade.github.io/OpenPBTA-analysis/analyses/molecular-subtyping-embryonal/04-table-prep.nb.html).
@@ -391,7 +390,7 @@ Additional details can be found in the analysis [notebook](https://alexslemonade
 1. Any RNA-seq biospecimen with _LIN28A_ overexpression, plus a _TYH1_ fusion (5' partner) with a gene adjacent or within the C19MC miRNA cluster and/or copy number amplification of the C19MC region was subtyped as `ETMR, C19MC-altered` (Embryonal tumor with multilayer rosettes, chromosome 19 miRNA cluster altered) [@doi:10.1007/s00401-012-1068-3; 10.1038/ng.2849].
 2. Any RNA-seq biospecimen with _LIN28A_ overexpression, a _TTYH1_ fusion (5' partner) with a gene adjacent or within the C19MC miRNA cluster but no evidence of copy number amplification of the C19MC region was subtyped as `ETMR, NOS` (Embryonal tumor with multilayer rosettes, not otherwise specified) [@doi:10.1007/s00401-012-1068-3; @doi:10.1038/ng.2849].
 3. Any RNA-seq biospecimen with a fusion having a 5' _MN1_ and 3' _BEND2_ or _CXXC5_ partner were subtyped as `CNS HGNET-MN1` (Central nervous system (CNS) high-grade neuroepithelial tumor with _MN1_ alteration).
-4. Non-MB and non-ATRT embryonal tumors with internal tandem duplication (as defined in this paper [@doi:10.1186/s12859-016-1031-8]) of _BCOR_ were subtyped as `CNS HGNET-BCOR` (CNS high-grade neuroepithelial tumor with _BCOR_ alteration).
+4. Non-MB and non-ATRT embryonal tumors with internal tandem duplication (as defined in [@doi:10.1186/s12859-016-1031-8]) of _BCOR_ were subtyped as `CNS HGNET-BCOR` (CNS high-grade neuroepithelial tumor with _BCOR_ alteration).
 5. Non-MB and non-ATRT embryonal tumors with over-expression and/or gene fusions in _FOXR2_ were subtyped as `CNS NB-FOXR2` (CNS neuroblastoma with _FOXR2_ activation).
 6. Non-MB and non-ATRT embryonal tumors with _CIC-NUTM1_ or other _CIC_ fusions, were subtyped as `CNS EFT-CIC` (CNS Ewing sarcoma family tumor with _CIC_ alteration) [@doi:/j.cell.2016.01.015]
 7. Non-MB and non-ATRT embryonal tumors that did not fit any of the above categories were subtyped as `CNS Embryonal, NOS` (CNS Embryonal tumor, not otherwise specified).

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -385,7 +385,7 @@ Note that the `MN1--PATZ1` fusion is excluded as it is an entity separate of CNS
 4. Any sample with "Neuroblastoma" in the `pathology_diagnosis` column, where `primary_site` does not contain "Other locations NOS", `pathology_free_text_diagnosis` does not contain "peripheral" or "metastatic".
 5. Any sample with "Other" in the `pathology_diagnosis` column of the metadata, and with "embryonal tumor with multilayer rosettes, ros (who grade iv)", "embryonal tumor, nos, congenital type", "ependymoblastoma" or "medulloepithelioma" in the `pathology_free_text_diagnosis` column.
 
-Non-MB and non-ATRT embryonal tumors generated subtypes were derived using the criteria below [@pmid:30249036; @doi:10.1007/s00381-017-3551-6; @url:https://www.cancer.gov/types/brain/hp/child-cns-embryonal-treatment-pdq; @doi:10.3390/ijms21051818].
+Non-MB and non-ATRT embryonal tumors identified with the above criteria were further subtyped using the criteria below [@pmid:30249036; @doi:10.1007/s00381-017-3551-6; @url:https://www.cancer.gov/types/brain/hp/child-cns-embryonal-treatment-pdq; @doi:10.3390/ijms21051818].
 Additional details can be found in the analysis [notebook](https://alexslemonade.github.io/OpenPBTA-analysis/analyses/molecular-subtyping-embryonal/04-table-prep.nb.html).
 
 1. Any RNA-seq biospecimen with _LIN28A_ overexpression, plus a _TYH1_ fusion (5' partner) with a gene adjacent or within the C19MC miRNA cluster and/or copy number amplification of the C19MC region was subtyped as `ETMR, C19MC-altered` (Embryonal tumor with multilayer rosettes, chromosome 19 miRNA cluster altered) [@doi:10.1007/s00401-012-1068-3; 10.1038/ng.2849].


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose
Updated the section for defining `Non-MB and non-ATRT embryonal tumors`. 

### Issue

https://github.com/AlexsLemonade/OpenPBTA-manuscript/issues/136

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?
I read the subtyping part and I felt it is already up-to-date so I only updated the part that subset `Non-MB and non-ATRT embryonal tumors`. Please see whether that is correct.

#### Is there anything that you want to discuss further?
No.

#### Is the pull request ready for review?
Yes.

### Pull review checklist

Unless otherwise noted above, this PR will be considered ready for review when all four items have been checked.

- [x] All changes to text follow "one sentence per line" [[Manubot instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#manubot-markdown)]
- [x] All citations follow the [Manubot citation instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#citations)
- [ ] All changes or additions to tables follow the [Manubot table instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#tables)
- [ ] All figures follow the [Manubot figure instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#figures)
- [ ] There are no new spelling errors identified by the [Manubot spellchecker](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#spellchecking)

### Spellcheck Step

The dictionary used for spellchecking can be updated.
Edit the file in `build/assets/custom-dictionary.txt` by adding new entries to the end.
You do not need to change anything else.
However, if you want to update the first line to have an accurate count of words and you want to remove non-unique ones, run the following command from within `build/assets` on your favorite OS X or Linux machine:
```
(( len = $(awk '!a[$0]++' < custom-dictionary.txt | wc -l ) - 1 )); tmpfile="$(mktemp)"; echo "personal_ws-1.1 en $len utf-8" > $tmpfile; tail -n +2 custom-dictionary.txt | awk '!a[$0]++' >> $tmpfile; mv $tmpfile custom-dictionary.txt
```
