### PR TITLE
Added description for molecular subtype integrate module

### DIFF
--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -398,11 +398,16 @@ Craniopharyngiomas (CRANIO) were subtyped into adamantinomatous (`CRANIO, ADAM`)
 
 A molecular subtype of `EWS` was assigned to any tumor with a _EWSR1_ fusion or with a `pathology_diagnosis` of `Ewings Sarcoma`. 
 
-After integrating molecular subtype, pathology diagnosis free text, clinical review and pathologist review into `broad_histology`, `short_histology`, `integrated_dignosis`, and `harmonized_diagnosis`, the compiled file was then used to update histology file. 
+After integrating molecular subtype, pathology diagnosis free text, clinical review and pathologist review into `broad_histology`, `short_histology`, `integrated_dignosis`, and `harmonized_diagnosis`, the compiled file was then used to update base histology file. 
 Firstly, for samples with pathology diagnosis of `Other` in the compiled file, manual curation of pathology diagnosis using pathology diagnosis free text was performed and relevant diagnosis and histology fields were updated.
-The updated compiled file was then used to populate base histology file with the following algorithm:
-1. If `broad_histology` was updated in the compiled file, `broad_histology` in the base histology file is 
+The updated compiled file was then used to populate base histology file with following steps:
+1. If `broad_histology` was updated in the compiled file, `broad_histology` in the base histology file was updated accordingly.
+2. If `short_histology` was updated in the compiled file, `short_histology` in the base histology file was updated accordingly.
+3. `harmonized_dignosis` was updated to `integrated_diagnosis` if `integrated_diagnosis` was available in the compiled file. 
+If not, `harmonized_diagnosis` was updated to `harmonized_diagnosis` in the compiled file. 
+If neither of `integrated_diagnosis` or `harmonized_diagnosis` was available in the compiled file, it would be updated to `pathology_diagnosis` in the compiled file. 
 
+The integrated histology file was then saved as the final histology file. 
 
 #### TP53 Alteration Annotation
 

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -398,6 +398,11 @@ Craniopharyngiomas (CRANIO) were subtyped into adamantinomatous (`CRANIO, ADAM`)
 
 A molecular subtype of `EWS` was assigned to any tumor with a _EWSR1_ fusion or with a `pathology_diagnosis` of `Ewings Sarcoma`. 
 
+After integrating molecular subtype, pathology diagnosis free text, clinical review and pathologist review into `broad_histology`, `short_histology`, `integrated_dignosis`, and `harmonized_diagnosis`, the compiled file was then used to update histology file. 
+Firstly, for samples with pathology diagnosis of `Other` in the compiled file, manual curation of pathology diagnosis using pathology diagnosis free text was performed and relevant diagnosis and histology fields were updated.
+The updated compiled file was then used to populate base histology file with the following algorithm:
+1. If `broad_histology` was updated in the compiled file, `broad_histology` in the base histology file is 
+
 
 #### TP53 Alteration Annotation
 


### PR DESCRIPTION
<!--Hi there, thanks for your contribution! Please take a moment to fill out this template to facilitate the review of your pull request.-->

### Purpose

Added description for molecular subtype integrate module.

### Issue
https://github.com/AlexsLemonade/OpenPBTA-manuscript/issues/136

### Directions for reviewers. Tell potential reviewers what kind of feedback you are soliciting.

#### Which areas should receive a particularly close look?
Please check whether it is too detailed or not. 


#### Is there anything that you want to discuss further?
No.

#### Is the pull request ready for review?
Yes.

### Pull review checklist

Unless otherwise noted above, this PR will be considered ready for review when all four items have been checked.

- [ ] All changes to text follow "one sentence per line" [[Manubot instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#manubot-markdown)]
- [ ] All citations follow the [Manubot citation instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#citations)
- [ ] All changes or additions to tables follow the [Manubot table instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#tables)
- [ ] All figures follow the [Manubot figure instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#figures)
- [ ] There are no new spelling errors identified by the [Manubot spellchecker](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#spellchecking)

### Spellcheck Step

The dictionary used for spellchecking can be updated.
Edit the file in `build/assets/custom-dictionary.txt` by adding new entries to the end.
You do not need to change anything else.
However, if you want to update the first line to have an accurate count of words and you want to remove non-unique ones, run the following command from within `build/assets` on your favorite OS X or Linux machine:
```
(( len = $(awk '!a[$0]++' < custom-dictionary.txt | wc -l ) - 1 )); tmpfile="$(mktemp)"; echo "personal_ws-1.1 en $len utf-8" > $tmpfile; tail -n +2 custom-dictionary.txt | awk '!a[$0]++' >> $tmpfile; mv $tmpfile custom-dictionary.txt
```
