### PR TITLE
Updated mutsig methods and added words to dictionary

### DIFF
--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -263,7 +263,6 @@ midline
 miRNA
 mis
 missense
-MMR2
 MNV
 monocytes
 Mortem
@@ -280,7 +279,6 @@ MYB
 MYBL
 MYC
 myeloid
-N6
 NantHealth
 NantOmics
 NCI

--- a/build/assets/custom-dictionary.txt
+++ b/build/assets/custom-dictionary.txt
@@ -66,6 +66,7 @@ CircleCI
 CJB
 CLS
 CNC
+CNS
 CNV
 CNVkit
 CNVs
@@ -262,6 +263,7 @@ midline
 miRNA
 mis
 missense
+MMR2
 MNV
 monocytes
 Mortem
@@ -278,6 +280,7 @@ MYB
 MYBL
 MYC
 myeloid
+N6
 NantHealth
 NantOmics
 NCI
@@ -353,6 +356,7 @@ README
 recalibrated
 recoded
 recombinant
+RefSig
 RELA
 reproducibility
 rhabdoid
@@ -447,6 +451,7 @@ VCFs
 VIS
 WDL
 WGS
+whichSignatures
 wikidata
 Wilcoxon
 wildtype

--- a/content/06.methods.md
+++ b/content/06.methods.md
@@ -298,7 +298,7 @@ The fusion filtering workflow can be found in the [OpenPBTA Analysis repository]
 
 #### Mutational Signatures
 
-We obtained weights (i.e. exposures) for signature sets using the `deconstructSigs` (version `1.8.0`) R package function `whichSignatures()` [@doi:10.1186/s13059-016-0893-4 ; @url:https://github.com/raerose01/deconstructSigs] from consensus SNVs with the BSgenome.Hsapiens.UCSC.hg38 annotations [@url:https://bioconductor.org/packages/release/data/annotation/html/BSgenome.Hsapiens.UCSC.hg38.html].
+We obtained weights (i.e., exposures) for signature sets using the `deconstructSigs` (version `1.8.0`) R package function `whichSignatures()` [@doi:10.1186/s13059-016-0893-4 ; @url:https://github.com/raerose01/deconstructSigs] from consensus SNVs with the BSgenome.Hsapiens.UCSC.hg38 annotations [@url:https://bioconductor.org/packages/release/data/annotation/html/BSgenome.Hsapiens.UCSC.hg38.html].
 Specifically, we estimated signature weights across samples for eight signatures previously identified in the Signal reference set of signatures ("RefSig") as associated with adult central nervous system (CNS) tumors [@doi:10.1038/s43018-020-0027-5].
 These eight RefSig signatures are 1, 3, 8, 11, 18, 19, N6, and MMR2.
 Weights for signatures fall in the range zero to one inclusive.

--- a/content/06.methods.md
+++ b/content/06.methods.md
@@ -298,7 +298,7 @@ The fusion filtering workflow can be found in the [OpenPBTA Analysis repository]
 
 #### Mutational Signatures
 
-We obtained weights (i.e., exposures) for signature sets using the `deconstructSigs` (version `1.8.0`) R package function `whichSignatures()` [@doi:10.1186/s13059-016-0893-4 ; @url:https://github.com/raerose01/deconstructSigs] from consensus SNVs with the BSgenome.Hsapiens.UCSC.hg38 annotations [@url:https://bioconductor.org/packages/release/data/annotation/html/BSgenome.Hsapiens.UCSC.hg38.html].
+We obtained weights (i.e., exposures) for signature sets using the `deconstructSigs` R package function `whichSignatures()` [@doi:10.1186/s13059-016-0893-4 ; @url:https://github.com/raerose01/deconstructSigs] from consensus SNVs with the BSgenome.Hsapiens.UCSC.hg38 annotations [@url:https://bioconductor.org/packages/release/data/annotation/html/BSgenome.Hsapiens.UCSC.hg38.html].
 Specifically, we estimated signature weights across samples for eight signatures previously identified in the Signal reference set of signatures ("RefSig") as associated with adult central nervous system (CNS) tumors [@doi:10.1038/s43018-020-0027-5].
 These eight RefSig signatures are 1, 3, 8, 11, 18, 19, N6, and MMR2.
 Weights for signatures fall in the range zero to one inclusive.

--- a/content/06.methods.md
+++ b/content/06.methods.md
@@ -170,7 +170,7 @@ In practice, because our filtered set was based on the intersection of these thr
 
 For some downstream analyses, only coding sequence SNVs (based on GENCODE v27 [@url:https://www.gencodegenes.org/human/release_27.html]) are used, to enhance comparability to other studies.
 We considered base pairs to be *effectively surveyed* if they were in the intersection of the genomic ranges considered by the callers used to generate the consensus and where appropriate, regions of interest, such as coding sequences.
-This definition of *effectively surveyed* base pairs is what is used to calculate effective genome size for calculations for tumor mutation burden and mutational signatures.
+This definition of *effectively surveyed* base pairs is what is used to calculate effective genome size for calculations for tumor mutation burden.
 
 ##### Recurrently mutated genes and co-occurrence of gene mutations
 
@@ -298,16 +298,12 @@ The fusion filtering workflow can be found in the [OpenPBTA Analysis repository]
 
 #### Mutational Signatures
 
-We obtained weights for signature sets by applying deconstructSigs [@doi:10.1186/s13059-016-0893-4 ; @url:https://github.com/raerose01/deconstructSigs] to consensus SNVs with the BSgenome.Hsapiens.UCSC.hg38 annotations [@url:https://bioconductor.org/packages/release/data/annotation/html/BSgenome.Hsapiens.UCSC.hg38.html].
-We estimated how many mutations contributed to each signature for each sample using each sample's signature weights.
+We obtained weights (i.e. exposures) for signature sets using the `deconstructSigs` (version `1.8.0`) R package function `whichSignatures()` [@doi:10.1186/s13059-016-0893-4 ; @url:https://github.com/raerose01/deconstructSigs] from consensus SNVs with the BSgenome.Hsapiens.UCSC.hg38 annotations [@url:https://bioconductor.org/packages/release/data/annotation/html/BSgenome.Hsapiens.UCSC.hg38.html].
+Specifically, we estimated signature weights across samples for eight signatures previously identified in the Signal reference set of signatures ("RefSig") as associated with adult central nervous system (CNS) tumors [@doi:10.1038/s43018-020-0027-5].
+These eight RefSig signatures are 1, 3, 8, 11, 18, 19, N6, and MMR2.
 Weights for signatures fall in the range zero to one inclusive.
-For a given sample and signature combination, we estimated the number of contributing mutations per Mb of the genome by multiplying the signature weight by the total number of trinucleotide mutations identified by deconstructSigs and then dividing by the size of the effectively surveyed genome.  
-
-$$ \frac{\textrm{# of contributing mutations}}{Mb} = \frac{\textrm{weight} * \sum{\textrm{# Trinucleotide mutations}}} {\textrm{Size in Mb of effectively surveyed genome}}
-$$
-
-These results do not include signatures with small contributions; deconstructSigs drops signature weights that are less than 6% [@doi:10.1186/s13059-016-0893-4].
-We used these methods to calculate signature scores for each sample with both COSMIC [@url:https://cancer.sanger.ac.uk/cosmic] and Alexandrov et al, 2013 [@doi:10.1038/nature12477] signature sets.
+`deconstructSigs` estimates the weights for each signature across samples and allows for a proportion of unassigned weights referred to as "Other" in the text.
+Note that these results do not include signatures with small contributions; `deconstructSigs` drops signature weights that are less than 6% [@doi:10.1186/s13059-016-0893-4].
 
 #### PBTA Tumor Mutation Burden
 

--- a/content/06.methods.md
+++ b/content/06.methods.md
@@ -303,7 +303,7 @@ Specifically, we estimated signature weights across samples for eight signatures
 These eight RefSig signatures are 1, 3, 8, 11, 18, 19, N6, and MMR2.
 Weights for signatures fall in the range zero to one inclusive.
 `deconstructSigs` estimates the weights for each signature across samples and allows for a proportion of unassigned weights referred to as "Other" in the text.
-Note that these results do not include signatures with small contributions; `deconstructSigs` drops signature weights that are less than 6% [@doi:10.1186/s13059-016-0893-4].
+These results do not include signatures with small contributions; `deconstructSigs` drops signature weights that are less than 6% [@doi:10.1186/s13059-016-0893-4].
 
 #### PBTA Tumor Mutation Burden
 


### PR DESCRIPTION
This PR addresses Issue #193 and updates the methods section for mutational signatures. 

Currently, I've included only the "final" analysis that uses `deconstructSigs` to fit the 8 CNS signatures. Do we want to include more information here about other aspects of the module? I would think no because interested parties can find this in the github.

 
### Pull review checklist

Unless otherwise noted above, this PR will be considered ready for review when all four items have been checked.

- [x] All changes to text follow "one sentence per line" [[Manubot instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#manubot-markdown)]
- [x] All citations follow the [Manubot citation instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#citations)
- [x] All changes or additions to tables follow the [Manubot table instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#tables)
- [x] All figures follow the [Manubot figure instructions](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#figures)
- [x] There are no new spelling errors identified by the [Manubot spellchecker](https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/master/USAGE.md#spellchecking)

### Spellcheck Step

The dictionary used for spellchecking can be updated.
Edit the file in `build/assets/custom-dictionary.txt` by adding new entries to the end.
You do not need to change anything else.
However, if you want to update the first line to have an accurate count of words and you want to remove non-unique ones, run the following command from within `build/assets` on your favorite OS X or Linux machine:
```
(( len = $(awk '!a[$0]++' < custom-dictionary.txt | wc -l ) - 1 )); tmpfile="$(mktemp)"; echo "personal_ws-1.1 en $len utf-8" > $tmpfile; tail -n +2 custom-dictionary.txt | awk '!a[$0]++' >> $tmpfile; mv $tmpfile custom-dictionary.txt
```
