### PR TITLE
Add Zenodo DOI for analysis release

### DIFF
--- a/content/06.methods.md
+++ b/content/06.methods.md
@@ -464,7 +464,7 @@ Next, we used multivariate Cox (proportional hazards) regression analysis [@doi:
 
 ### KEY RESOURCES TABLE
 
-| REAGENT or RESOURCE                           | SOURCE                                                       | IDENTIFIER                                                                                                    |   |
+| REAGENT or RESOURCE                           | SOURCE                                                       | IDENTIFIER                                                                                                    |
 |-----------------------------------------------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
 | Critical commercial assays                    |                                                              |                                                                                                               |
 | Recover Cell Culture Freezing media           | Gibco                                                        | 12648010                                                                                                      |
@@ -500,7 +500,7 @@ Next, we used multivariate Cox (proportional hazards) regression analysis [@doi:
 | Software and algorithms                       |                                                              |                                                                                                               |
 | Data processing and analysis software         | Multiple                                                     | See **Table S5** for identifiers                                                                              |
 | OpenPBTA workflows repository                 | this project                                                 | [@doi:10.5281/zenodo.6968175]                                                                                 |
-| OpenPBTA analysis repository                  | this project                                                 |                                                                                                               |
+| OpenPBTA analysis repository                  | this project                                                 | [@doi:10.5281/zenodo.7044567]                                                                                                           |
 | OpenPBTA manuscript repository                | this project                                                 |                                                                                                               |
 |                                               |                                                              |                                                                                                               |
 | Other                                         |                                                              |                                                                                                               |


### PR DESCRIPTION
Partially addresses https://github.com/AlexsLemonade/OpenPBTA-manuscript/issues/196

I'm adding the DOI for the analysis repo now that we have one. I also removed an extra `|` in the header that was preventing the table from rendering.