### PR TITLE
Update Nicholas Van Kuren spelling

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -337,7 +337,7 @@ authors:
   - Division of Neurosurgery, Children's Hospital of Philadelphia
   - Center for Data-Driven Discovery in Biomedicine, Children's Hospital of Philadelphia
 - github: nicholasvk
-  name: Nicolas Van Kuren
+  name: Nicholas Van Kuren
   initials: NK
   orcid: 0000-0002-7414-9516
   email: vankurenn@chop.edu

--- a/submission_info/author_information.tsv
+++ b/submission_info/author_information.tsv
@@ -24,7 +24,7 @@ Stephen C. Mack	Department of Developmental Neurobiology, St. Jude Children's Re
 Pichai Raman	Center for Data-Driven Discovery in Biomedicine, Children's Hospital of Philadelphia; Department of Bioinformatics and Health Informatics, Children's Hospital of Philadelphia	0000-0001-6948-2157	pichai.raman@gmail.com
 Siyuan Zheng	Greehey Children's Cancer Research Institute, UT Health San Antonio	0000-0002-1031-9424	zhengs3@uthscsa.edu
 Peter J. Madsen	Division of Neurosurgery, Children's Hospital of Philadelphia; Center for Data-Driven Discovery in Biomedicine, Children's Hospital of Philadelphia	0000-0001-9266-3685	madsenp@chop.edu
-Nicolas Van Kuren	Center for Data-Driven Discovery in Biomedicine, Children's Hospital of Philadelphia; Division of Neurosurgery, Children's Hospital of Philadelphia	0000-0002-7414-9516	vankurenn@chop.edu
+Nicholas Van Kuren	Center for Data-Driven Discovery in Biomedicine, Children's Hospital of Philadelphia; Division of Neurosurgery, Children's Hospital of Philadelphia	0000-0002-7414-9516	vankurenn@chop.edu
 Shannon Robins	Center for Data-Driven Discovery in Biomedicine, Children's Hospital of Philadelphia; Division of Neurosurgery, Children's Hospital of Philadelphia	0000-0003-0594-1953	Shannonmrobins@gmail.com
 Xiaoyan Huang	Center for Data-Driven Discovery in Biomedicine, Children's Hospital of Philadelphia; Division of Neurosurgery, Children's Hospital of Philadelphia	0000-0001-7267-4512	huangx@chop.edu
 Angela J. Waanders	Division of Hematology, Oncology, Neuro-Oncology, and Stem Cell Transplant, Ann & Robert H Lurie Children's Hospital of Chicago; Department of Pediatrics, Northwestern University Feinberg School of Medicine	0000-0002-0571-2889	awaanders@luriechildrens.org


### PR DESCRIPTION
Discovered during submission to _bioRxiv_ because the ORCID could not be located: https://orcid.org/0000-0002-7414-9516