### PR TITLE
Add sentence to data availability about figure data Zenodo accession

### DIFF
--- a/content/07.methods.md
+++ b/content/07.methods.md
@@ -16,6 +16,7 @@ Raw and harmonized WGS, WXS, and RNA-Seq data derived from human samples are ava
 In addition, merged summary files are openly accessible at [https://cavatica.sbgenomics.com/u/cavatica/openpbta](https://cavatica.sbgenomics.com/u/cavatica/openpbta) or via download script in the  [https://github.com/AlexsLemonade/OpenPBTA-analysis](https://github.com/AlexsLemonade/OpenPBTA-analysis) repository.
 Summary data are visible within PedcBioPortal at [https://pedcbioportal.kidsfirstdrc.org/study/summary?id=openpbta](https://pedcbioportal.kidsfirstdrc.org/study/summary?id=openpbta).
 Associated DOIs are listed in the **Key Resources Table**.
+Data underlying manuscript figures are available on Zenodo [@doi:10.5281/zenodo.7805408].
 <!-- TODO: create data dois -->
 
 All original code was developed within the following repositories and is publicly available as follows.


### PR DESCRIPTION
Closes #426. I've added a sentence to the data and code availability section about the figure data Zenodo upload. I decided it doesn't necessarily make sense to include this in the Key Resources table since it is an output of the paper rather than a resource we utilized that is necessary to reproduce our work. I am open to other opinions about that!